### PR TITLE
Enable submodule access for Claude code reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          submodules: recursive
 
       - name: Run Claude Code Review
         id: claude-review


### PR DESCRIPTION
This PR adds recursive submodule initialization to the Claude workflow so that Claude can access and review test files in the writing-a-c-compiler-tests submodule.

Without this change, Claude cannot see the test files and may provide incomplete reviews.

This is a quick fix that needs to be merged to main before other PRs can fully benefit from Claude's review capabilities.