### PR TITLE
Switch Statements & Parser Improvements

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,9 +2,8 @@ name: Tests & Coverage
 
 on:
   push:
-    branches: [ '**' ]
-  pull_request:
     branches: [ main ]
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,8 @@ name: Lint
 
 on:
   push:
-    branches: [ '**' ]
-  pull_request:
     branches: [ main ]
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -73,8 +73,23 @@ The compiler supports:
 - **Expression statements** and **null statements**
 
 ### Safer C
-- We enforce left to right evaluation of binary operations to avoid undefined behavior.
-- The compiler emits warnings for variable shadowing to help catch potential bugs.
+
+NCC provides several safety features and guarantees to help developers write more reliable code:
+
+#### Guaranteed Behaviors
+- **Deterministic integer overflow**: Integer arithmetic uses two's complement wrapping (32-bit). For example, `INT_MAX + 1` reliably wraps to `INT_MIN`.
+- **Left-to-right evaluation**: Binary operations are evaluated left to right, eliminating undefined behavior from evaluation order.
+
+#### Compile-Time Warnings
+- **Variable shadowing** (`Wshadow`): Warns when a variable declaration shadows a previous declaration in an outer scope
+- **Duplicate switch cases** (` Wswitch-unreachable`): Detects and reports duplicate case values in switch statements, including those from constant expressions
+
+#### Developer Experience
+- **Precise error locations**: All errors and warnings include exact line and column numbers with file:line:column format, making it easy to locate problematic code
+- **Contextual error messages**: Semantic errors reference related code locations (e.g., showing both the shadowing variable and the original declaration)
+- **Pretty-printed ASTs**: Visual tree representations of parsed code (`--parse`), intermediate representations (`--tacky`), and generated code (`--codegen`) for debugging and understanding compilation stages
+
+These features help catch common bugs at compile time while providing predictable runtime behavior.
 
 ## Requirements
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -5,7 +5,7 @@
 A simple C compiler written in Rust, following Sandler's "Writing a C Compiler".
 Some design decisions are informed by the book but the implementation is my own.
 
-So far chapter 8 (including extra credit up to chapter 7) is implemented, which includes a lexer, parser, semantic analysis, and code generator for C code with local variables, compound statements, and loops.
+So far chapter 8, including extra credit is implemented, which includes a lexer, parser, semantic analysis, and code generator for C code with local variables, compound statements, loops, and switch statements.
 This compiler is a fully standalone executable; it does not rely on any external programs for assembling or linking (on Linux).
 All provided tests pass.
 
@@ -31,6 +31,9 @@ The compiler currently implements a subset of C with the following grammar:
             | "while" "(" <exp> ")" <statement>
             | "do" <statement> "while" "(" <exp> ")" ";"
             | "for" "(" <for-init> [ <exp> ] ";" [ <exp> ] ")" <statement>
+            | "switch" "(" <exp> ")" <statement>
+            | "case" <exp> ":" <statement>
+            | "default" ":" <statement>
             | ";"
 <exp> ::= <factor> | <exp> <binop> <exp> | <exp> <assign-op> <exp> 
        | <exp> "?" <exp> ":" <exp> | <exp> "++" | <exp> "--"
@@ -59,6 +62,7 @@ The compiler supports:
 - **Conditional (ternary) operator**: `condition ? true_expr : false_expr`
 - **Control flow**:
   - `if`/`else` statements
+  - `switch` statements with `case` and `default` labels
   - `while` loops
   - `do-while` loops
   - `for` loops with all three components (init, condition, update)

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -278,7 +278,7 @@ fn convert_unary_op(op: &parser::UnaryOp) -> UnaryOp {
 
 fn convert_val(ast: &tacky::Val) -> Operand {
     match ast {
-        tacky::Val::Constant(value) => Operand::Imm(*value),
+        tacky::Val::Constant(value) => Operand::Imm(*value as i64),
         tacky::Val::Var(s) => Operand::Pseudo(s.clone()),
     }
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -8,7 +8,7 @@ use std::sync::LazyLock;
 #[derive(Clone, Debug, PartialEq)]
 pub enum Token {
     Identifier(String),
-    ConstantInt(i64),
+    ConstantInt(i32),
     IntKeyword,              // int
     VoidKeyword,             // void
     ReturnKeyword,           // return
@@ -60,6 +60,9 @@ pub enum Token {
     ForKeyword,              // for
     BreakKeyword,            // break
     ContinueKeyword,         // continue
+    SwitchKeyword,           // switch
+    DefaultKeyword,          // default
+    CaseKeyword,             // case
 }
 
 const TOKEN_PATTERNS: &[(&str, Token)] = &[
@@ -125,6 +128,9 @@ const TOKEN_PATTERNS: &[(&str, Token)] = &[
     (r"^for\b", Token::ForKeyword),
     (r"^break\b", Token::BreakKeyword),
     (r"^continue\b", Token::ContinueKeyword),
+    (r"^switch\b", Token::SwitchKeyword),
+    (r"^default\b", Token::DefaultKeyword),
+    (r"^case\b", Token::CaseKeyword),
 ];
 
 static TOKEN_DEFS: LazyLock<Vec<TokenDef>, fn() -> Vec<TokenDef>> = LazyLock::new(|| {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -258,6 +258,9 @@ pub(crate) fn tokenizer(mut input: &str) -> Result<VecDeque<SpannedToken>, Lexer
                 line += 1;
                 col = 1;
                 input = &input[newline_index + 1..];
+            } else {
+                // End of file reached with // or # comment - skip rest of input
+                break;
             }
             continue;
         } else if input.starts_with("/*") {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -8,7 +8,7 @@ use std::sync::LazyLock;
 #[derive(Clone, Debug, PartialEq)]
 pub enum Token {
     Identifier(String),
-    ConstantInt(i32),
+    ConstantInt(String),
     IntKeyword,              // int
     VoidKeyword,             // void
     ReturnKeyword,           // return
@@ -68,7 +68,7 @@ pub enum Token {
 const TOKEN_PATTERNS: &[(&str, Token)] = &[
     // Special handling tokens (handled differently in next_token)
     (r"^[a-zA-Z_]\w*\b", Token::Identifier(String::new())),
-    (r"^[0-9]+\b", Token::ConstantInt(0)),
+    (r"^[0-9]+\b", Token::ConstantInt(String::new())),
     // Keywords
     (r"^int\b", Token::IntKeyword),
     (r"^void\b", Token::VoidKeyword),
@@ -194,7 +194,7 @@ fn next_token(input: &str, span: Span) -> Result<TokenMatch, LexerError> {
         if let Some(mat) = regex.find(input) {
             let token = match variant {
                 Token::Identifier(_) => Token::Identifier(mat.as_str().to_string()),
-                Token::ConstantInt(_) => Token::ConstantInt(mat.as_str().parse().unwrap()),
+                Token::ConstantInt(_) => Token::ConstantInt(mat.as_str().to_string()),
                 other => other.clone(),
             };
             matches.push(TokenMatch {

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,7 +260,7 @@ pub mod test_utils {
     use std::path::Path;
 
     static CHAPTER_COMPLETED: i32 = 8;
-    static EXTRA_COMPLETED: i32 = 7;
+    static EXTRA_COMPLETED: i32 = 8;
     pub enum Stage {
         Lex,
         Parse,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -139,33 +139,56 @@ pub enum SwitchIntType {
     Default
 }
 
+impl SwitchIntType {
+    pub fn label_str(&self, switch_num: u64) -> String {
+        match self {
+            SwitchIntType::Int(val) => {
+                if *val >= 0 {
+                    format!("switch.{switch_num}_case.{val}")
+                } else {
+                    let c_str = &val.to_string()[1..];
+                    format!("switch.{switch_num}_case.neg{c_str}")
+                }
+            }
+            SwitchIntType::Default => {
+                format!("switch.{switch_num}_default")
+            }
+        }
+    }
+}
+
 //todo refactor with spannedstmt struct
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+pub struct SpannedStmt {
+    pub stmt: Stmt,
+    pub span: Span
+}
+#[derive(Debug, Clone)]
 pub enum Stmt {
     Return(Expr),
     Expression(Expr),
-    If(Expr, Box<Stmt>, Box<Option<Stmt>>), // if (controlling expression, then, else)
-    Goto(Identifier, Span),
-    Labeled(Identifier, Box<Stmt>, Span),
+    If(Expr, Box<SpannedStmt>, Box<Option<SpannedStmt>>), // if (controlling expression, then, else)
+    Goto(Identifier),
+    Labeled(Identifier, Box<SpannedStmt>),
     Compound(Block),
-    Break(Identifier, Span),
-    Continue(Identifier, Span),
-    While(Expr, Box<Stmt>, u64),                              // while(condition, body, label)
-    DoWhile(Box<Stmt>, Expr, u64),                            // dowhile(body, condition, label)
-    For(ForInit, Option<Expr>, Option<Expr>, Box<Stmt>, u64), // for(init, condition, post, body, label)
-    Switch(Expr, Box<Stmt>, u64, HashSet<SwitchIntType>),
-    Case(Expr, Box<Stmt>, Identifier, Span),
-    Default(Box<Stmt>, Identifier, Span),
+    Break(Identifier),
+    Continue(Identifier),
+    While(Expr, Box<SpannedStmt>, u64),                              // while(condition, body, label)
+    DoWhile(Box<SpannedStmt>, Expr, u64),                            // dowhile(body, condition, label)
+    For(ForInit, Option<Expr>, Option<Expr>, Box<SpannedStmt>, u64), // for(init, condition, post, body, label)
+    Switch(Expr, Box<SpannedStmt>, u64, HashSet<SwitchIntType>),
+    Case(Expr, Box<SpannedStmt>, Identifier),
+    Default(Box<SpannedStmt>, Identifier),
     Null,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ForInit {
     InitDecl(Declaration),
     InitExp(Option<Expr>),
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone)]
 pub struct Declaration {
     pub name: Identifier,
     pub init: Option<Expr>,
@@ -185,9 +208,9 @@ impl fmt::Debug for Declaration {
 
 pub type Block = Vec<BlockItem>;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum BlockItem {
-    Statement(Stmt),
+    Statement(SpannedStmt),
     Declaration(Declaration),
 }
 
@@ -286,11 +309,29 @@ fn parse_factor(tokens: &mut VecDeque<SpannedToken>) -> Result<Expr, SyntaxError
     let next_token = tokens.front().cloned();
     let mut expr = match next_token {
         Some(ref spanned) => match &spanned.token {
-            Token::ConstantInt(value) => {
+            Token::ConstantInt(value_str) => {
                 tokens.pop_front();
-                Ok(Expr::Constant(*value))
+                match value_str.parse::<i32>() {
+                    Ok(val) => Ok(Expr::Constant(val)),
+                    Err(_) => Err(SyntaxError::with_span(
+                        format!("Integer constant '{}' does not fit in 32-bit int", value_str.bold()),
+                        Some(spanned.span),
+                    ))
+                }
             }
-            Token::BitwiseComplement | Token::Negation | Token::LogicalNot => {
+            Token::Negation => {
+                // simply treating negation as an unop cases a panic when unwrapping int min
+                if let Some(SpannedToken{token: Token::ConstantInt(value_str), span: _}) = tokens.get_mut(1) {
+                    *value_str = format!("-{value_str}");
+                    tokens.pop_front();
+                    parse_factor(tokens)
+                } else {
+                    let operator = parse_unop(tokens)?;
+                    let inner_exp = parse_factor(tokens)?;
+                    Ok(Expr::Unary(operator, Box::from(inner_exp)))
+                }
+            }
+            Token::BitwiseComplement | Token::LogicalNot => {
                 let operator = parse_unop(tokens)?;
                 let inner_exp = parse_factor(tokens)?;
                 Ok(Expr::Unary(operator, Box::from(inner_exp)))
@@ -461,23 +502,23 @@ fn parse_identifier(tokens: &mut VecDeque<SpannedToken>) -> Result<(Identifier, 
     }
 }
 
-fn parse_statement(tokens: &mut VecDeque<SpannedToken>) -> Result<Stmt, SyntaxError> {
+fn parse_statement(tokens: &mut VecDeque<SpannedToken>) -> Result<SpannedStmt, SyntaxError> {
     let Some(next_token) = tokens.front().cloned() else {
         unreachable!("parse_statement called with no token")
     };
     match next_token.token {
         Token::ReturnKeyword => {
-            tokens.pop_front();
+            let span =tokens.pop_front().unwrap().span;
             let exp = parse_exp(tokens, 0)?;
             expect(&Token::Semicolon, tokens)?;
-            Ok(Stmt::Return(exp))
+            Ok(SpannedStmt {stmt: Stmt::Return(exp), span})
         }
         Token::Semicolon => {
-            tokens.pop_front();
-            Ok(Stmt::Null)
+            let span =tokens.pop_front().unwrap().span;
+            Ok(SpannedStmt {stmt: Stmt::Null, span})
         }
         Token::IfKeyword => {
-            tokens.pop_front();
+            let span =tokens.pop_front().unwrap().span;
             let condition = get_condition(tokens)?;
             let then_stmt = parse_statement(tokens)?;
             // check for else
@@ -487,13 +528,14 @@ fn parse_statement(tokens: &mut VecDeque<SpannedToken>) -> Result<Stmt, SyntaxEr
             } else {
                 None
             };
-            Ok(Stmt::If(condition, Box::new(then_stmt), Box::new(else_stmt)))
+            let stmt = Stmt::If(condition, Box::new(then_stmt), Box::new(else_stmt));
+            Ok(SpannedStmt{stmt, span})
         }
         Token::GotoKeyword => {
-            let goto_span = tokens.pop_front().unwrap().span;
-            let (target, _span) = parse_identifier(tokens)?;
+            let span = tokens.pop_front().unwrap().span;
+            let (target, _) = parse_identifier(tokens)?;
             expect(&Token::Semicolon, tokens)?;
-            Ok(Stmt::Goto(target, goto_span))
+            Ok(SpannedStmt{stmt: Stmt::Goto(target), span})
         }
         Token::Identifier(label_name) => {
             // Check if it's a label (identifier followed by colon)
@@ -503,49 +545,49 @@ fn parse_statement(tokens: &mut VecDeque<SpannedToken>) -> Result<Stmt, SyntaxEr
                 tokens.pop_front(); // consume colon
                 declaration_check(tokens)?;
                 let stmt = parse_statement(tokens)?;
-                Ok(Stmt::Labeled(label, Box::new(stmt), span))
+                Ok(SpannedStmt {stmt: Stmt::Labeled(label, Box::new(stmt)), span})
             } else {
                 // It's an expression statement
                 let expr = parse_exp(tokens, 0)?;
-                expect(&Token::Semicolon, tokens)?;
-                Ok(Stmt::Expression(expr))
+                let span = expect(&Token::Semicolon, tokens)?;
+                Ok(SpannedStmt {stmt: Stmt::Expression(expr), span})
             }
         }
         Token::OpenBrace => {
-            tokens.pop_front();
+            let span = tokens.pop_front().unwrap().span;
             let mut block = Vec::new();
             while tokens.front().map(|t| &t.token) != Some(&Token::CloseBrace) {
                 block.push(parse_block_item(tokens)?);
             }
             expect(&Token::CloseBrace, tokens)?;
-            Ok(Stmt::Compound(block))
+            Ok(SpannedStmt {stmt: Stmt::Compound(block), span})
         }
         Token::BreakKeyword => {
             let span = tokens.pop_front().unwrap().span;
             expect(&Token::Semicolon, tokens)?;
-            Ok(Stmt::Break(Identifier("_dummy".to_string()), span))
+            Ok(SpannedStmt{ stmt: Stmt::Break(Identifier("_dummy".to_string())), span})
         }
         Token::ContinueKeyword => {
             let span = tokens.pop_front().unwrap().span;
             expect(&Token::Semicolon, tokens)?;
-            Ok(Stmt::Continue(Identifier("_dummy".to_string()), span))
+            Ok(SpannedStmt{ stmt: Stmt::Continue(Identifier("_dummy".to_string())), span})
         }
         Token::WhileKeyword => {
-            tokens.pop_front();
+            let span = tokens.pop_front().unwrap().span;
             let condition = get_condition(tokens)?;
             let body = parse_statement(tokens)?;
-            Ok(Stmt::While(condition, Box::from(body), 0))
+            Ok(SpannedStmt{stmt: Stmt::While(condition, Box::from(body), 0), span})
         }
         Token::DoKeyword => {
-            tokens.pop_front();
+            let span = tokens.pop_front().unwrap().span;
             let body = parse_statement(tokens)?;
             expect(&Token::WhileKeyword, tokens)?;
             let condition = get_condition(tokens)?;
             expect(&Token::Semicolon, tokens)?;
-            Ok(Stmt::DoWhile(Box::from(body), condition, 0))
+            Ok(SpannedStmt{stmt: Stmt::DoWhile(Box::from(body), condition, 0), span})
         }
         Token::ForKeyword => {
-            tokens.pop_front();
+            let span = tokens.pop_front().unwrap().span;
             let err_span = expect(&Token::OpenParen, tokens)?;
             let init = if let Some(dec) = parse_declaration(tokens, &Some(err_span))? {
                 ForInit::InitDecl(dec)
@@ -559,7 +601,7 @@ fn parse_statement(tokens: &mut VecDeque<SpannedToken>) -> Result<Stmt, SyntaxEr
             let post = parse_exp(tokens, 0).ok();
             expect(&Token::CloseParen, tokens)?;
             let body = parse_statement(tokens)?;
-            Ok(Stmt::For(init, condition, post, Box::from(body), 0))
+            Ok(SpannedStmt{stmt: Stmt::For(init, condition, post, Box::from(body), 0), span})
         }
         Token::CaseKeyword => {
             let span = tokens.pop_front().unwrap().span;
@@ -567,49 +609,47 @@ fn parse_statement(tokens: &mut VecDeque<SpannedToken>) -> Result<Stmt, SyntaxEr
             expect(&Token::Colon, tokens)?;
             declaration_check(tokens)?;
             let stmt = parse_statement(tokens)?;
-            Ok(Stmt::Case(exp, Box::from(stmt), Identifier("_dummy".to_string()), span))
+            Ok(SpannedStmt{stmt: Stmt::Case(exp, Box::from(stmt), Identifier("_dummy".to_string())), span})
         }
         Token::DefaultKeyword => {
             let span = tokens.pop_front().unwrap().span;
             expect(&Token::Colon, tokens)?;
             declaration_check(tokens)?;
             let stmt = parse_statement(tokens)?;
-            Ok(Stmt::Default(Box::from(stmt), Identifier("_dummy".to_string()), span))
+            Ok(SpannedStmt{stmt: Stmt::Default(Box::from(stmt), Identifier("_dummy".to_string())), span})
         }
         Token::SwitchKeyword => {
-            //todo repalce with stmt span when available
-            let span =tokens.pop_front().unwrap().span;
+            let span = tokens.pop_front().unwrap().span;
             expect(&Token::OpenParen, tokens)?;
             let exp = parse_exp(tokens, 0)?;
             expect(&Token::CloseParen, tokens)?;
             let stmt = parse_statement(tokens)?;
             // check for stmt before first case
-            match &stmt {
-                Stmt::Case(..) | Stmt::Default(..) => {}
-                Stmt::Compound(block) => {
-                    if let Some(BlockItem::Statement(s)) = block.first() {
-                        eprintln!(
-                            "{}: {}: statement will never be executed {}",
-                            span,
-                            "warning".purple(),
-                            "[-Wswitch-unreachable]".purple()
-                        );
-                    }
-                }
-                _ => eprintln!(
-                    "{}: {}: statement will never be executed {}",
-                    span,
-                    "warning".purple(),
-                    "[-Wswitch-unreachable]".purple()
-                )
-            }
-            Ok(Stmt::Switch(exp, Box::from(stmt), 0, HashSet::new()))
+            switch_unreachable_check(&stmt);
+            Ok(SpannedStmt{stmt: Stmt::Switch(exp, Box::from(stmt), 0, HashSet::new()), span})
         }
         _ => {
             let expr = parse_exp(tokens, 0)?;
-            expect(&Token::Semicolon, tokens)?;
-            Ok(Stmt::Expression(expr))
+            let span = expect(&Token::Semicolon, tokens)?;
+            Ok(SpannedStmt{stmt: Stmt::Expression(expr), span})
         }
+    }
+}
+
+fn switch_unreachable_check(stmt: &SpannedStmt) {
+    match &stmt.stmt {
+        Stmt::Case(..) | Stmt::Default(..) | Stmt::Null => {}
+        Stmt::Compound(block) => {
+            if let Some(BlockItem::Statement(s)) = block.first() {
+                switch_unreachable_check(s)
+            }
+        }
+        _ => eprintln!(
+            "{}: {}: statement will never be executed {}",
+            stmt.span,
+            "warning".purple(),
+            "[-Wswitch-unreachable]".purple()
+        )
     }
 }
 
@@ -635,8 +675,8 @@ fn parse_block_item(tokens: &mut VecDeque<SpannedToken>) -> Result<BlockItem, Sy
     if let Some(dec) = parse_declaration(tokens, &None)? {
         Ok(BlockItem::Declaration(dec))
     } else {
-        let stmt = parse_statement(tokens)?;
-        Ok(BlockItem::Statement(stmt))
+        let spanned_stmt = parse_statement(tokens)?;
+        Ok(BlockItem::Statement(spanned_stmt))
     }
 }
 
@@ -753,6 +793,12 @@ impl ItfDisplay for Expr {
         }
     }
 }
+impl ItfDisplay for SpannedStmt {
+    fn itf_node(&self) -> Node {
+        self.stmt.itf_node()
+    }
+}
+
 impl ItfDisplay for Stmt {
     fn itf_node(&self) -> Node {
         match self {
@@ -761,16 +807,16 @@ impl ItfDisplay for Stmt {
             Stmt::If(condition, then_stmt, else_stmt) => {
                 let mut children = vec![
                     Node::branch("condition:", vec![condition.itf_node()]),
-                    Node::branch("then:", vec![then_stmt.itf_node()]),
+                    Node::branch("then:", vec![then_stmt.stmt.itf_node()]),
                 ];
                 if let Some(else_s) = else_stmt.as_ref() {
-                    children.push(Node::branch("else:", vec![else_s.itf_node()]));
+                    children.push(Node::branch("else:", vec![else_s.stmt.itf_node()]));
                 }
                 Node::branch(cyan("If"), children)
             }
             Stmt::Null => Node::leaf(cyan("Null")),
-            Stmt::Goto(label, _) => Node::branch(cyan("Goto"), vec![label.itf_node()]),
-            Stmt::Labeled(label, stmt, _) => Node::branch(cyan("Labeled"), vec![label.itf_node(), stmt.itf_node()]),
+            Stmt::Goto(label) => Node::branch(cyan("Goto"), vec![label.itf_node()]),
+            Stmt::Labeled(label, stmt) => Node::branch(cyan("Labeled"), vec![label.itf_node(), stmt.stmt.itf_node()]),
             Stmt::Compound(block) => {
                 let children: Vec<Node> = block.iter().map(|item| item.itf_node()).collect();
                 Node::branch(cyan("Compound"), children)
@@ -781,13 +827,13 @@ impl ItfDisplay for Stmt {
                 cyan("While"),
                 vec![
                     Node::branch("condition:", vec![condition.itf_node()]),
-                    Node::branch("body:", vec![body.itf_node()]),
+                    Node::branch("body:", vec![body.stmt.itf_node()]),
                 ],
             ),
             Stmt::DoWhile(body, condition, _) => Node::branch(
                 cyan("DoWhile"),
                 vec![
-                    Node::branch("body:", vec![body.itf_node()]),
+                    Node::branch("body:", vec![body.stmt.itf_node()]),
                     Node::branch("condition:", vec![condition.itf_node()]),
                 ],
             ),
@@ -799,7 +845,7 @@ impl ItfDisplay for Stmt {
                 if let Some(post_expr) = post {
                     children.push(Node::branch("post:", vec![post_expr.itf_node()]));
                 }
-                children.push(Node::branch("body:", vec![body.itf_node()]));
+                children.push(Node::branch("body:", vec![body.stmt.itf_node()]));
                 Node::branch(cyan("For"), children)
             }
             Stmt::Switch(expr, body, ..) => {
@@ -807,21 +853,21 @@ impl ItfDisplay for Stmt {
                     cyan("Switch"),
                     vec![
                         Node::branch("expr:", vec![expr.itf_node()]),
-                        Node::branch("body:", vec![body.itf_node()]),
+                        Node::branch("body:", vec![body.stmt.itf_node()]),
                     ],
                 )
             }
-            Stmt::Case(expr, stmt, _, _) => {
+            Stmt::Case(expr, stmt, _) => {
                 Node::branch(
                     cyan("Case"),
                     vec![
                         Node::branch("expr:", vec![expr.itf_node()]),
-                        Node::branch("stmt:", vec![stmt.itf_node()]),
+                        Node::branch("stmt:", vec![stmt.stmt.itf_node()]),
                     ],
                 )
             }
             Stmt::Default(stmt, ..) => {
-                Node::branch(cyan("Default"), vec![stmt.itf_node()])
+                Node::branch(cyan("Default"), vec![stmt.stmt.itf_node()])
             }
         }
     }

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -95,11 +95,21 @@ impl ItfDisplay for &str {
     }
 }
 
-impl ItfDisplay for i64 {
-    fn itf_node(&self) -> Node {
-        Node::leaf(magenta(self))
+// Macro to implement ItfDisplay for all integer types
+macro_rules! impl_itf_display_for_int {
+    ($($t:ty),*) => {
+        $(
+            impl ItfDisplay for $t {
+                fn itf_node(&self) -> Node {
+                    Node::leaf(magenta(self.to_string()))
+                }
+            }
+        )*
     }
 }
+
+// Implement for all integer types
+impl_itf_display_for_int!(i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize);
 
 impl<T: ItfDisplay> ItfDisplay for Vec<T> {
     fn itf_node(&self) -> Node {

--- a/src/tacky.rs
+++ b/src/tacky.rs
@@ -1,4 +1,4 @@
-use crate::{parser};
+use crate::parser;
 use crate::parser::{Block, BlockItem, Declaration, Expr, ForInit, Identifier, IncDec, Stmt, UnaryOp};
 use crate::pretty::{ItfDisplay, Node, cyan, simple_node};
 use crate::tacky::Instruction::{JumpIfNotZero, JumpIfZero};
@@ -424,7 +424,7 @@ fn tackify_stmt(stmt: &parser::Stmt, instructions: &mut Vec<Instruction>, name_g
         Stmt::Switch(exp, stmt, switch_num, cases) => {
             let end_label = Identifier(format!("break_switch.{switch_num}"));
             let switch_val = tackify_expr(exp, instructions, name_generator);
-            
+
             // Build conditional jumps for each case
             // this can be optimized with binary search and/or jump tables
             let mut default_label = None;
@@ -450,13 +450,15 @@ fn tackify_stmt(stmt: &parser::Stmt, instructions: &mut Vec<Instruction>, name_g
                     }
                 }
             }
-            
+
             // Jump to default if it exists, otherwise jump to end
             // cases following default will execute this is expected
             if let Some(default) = default_label {
                 instructions.push(Instruction::Jump { target: default });
             } else {
-                instructions.push(Instruction::Jump { target: end_label.clone() });
+                instructions.push(Instruction::Jump {
+                    target: end_label.clone(),
+                });
             }
 
             tackify_stmt(&stmt.stmt, instructions, name_generator);

--- a/tests/c_programs/expected_results.json
+++ b/tests/c_programs/expected_results.json
@@ -28,5 +28,23 @@
   },
   "evaluation_order/test_postinc.c": {
     "return_code": 5
+  },
+  "loops/complex_loop_expressions_simple.c": {
+    "return_code": 35
+  },
+  "loops/empty_for_components.c": {
+    "return_code": 17
+  },
+  "loops/nested_dowhile_continue.c": {
+    "return_code": 22
+  },
+  "loops/deeply_nested_loops.c": {
+    "return_code": 35
+  },
+  "loops/debug_conditional_break.c": {
+    "return_code": 2
+  },
+  "loops/debug_middle_break.c": {
+    "return_code": 10
   }
 }

--- a/tests/c_programs/expected_results.json
+++ b/tests/c_programs/expected_results.json
@@ -46,5 +46,17 @@
   },
   "loops/debug_middle_break.c": {
     "return_code": 10
+  },
+  "switch/complex_const_int.c": {
+    "return_code": 16
+  },
+  "int_wrapping/int_wrapping.c": {
+    "return_code": 0
+  },
+  "int_wrapping/loop_wrapping.c": {
+    "return_code": 2
+  },
+  "int_wrapping/overflow_tests.c": {
+    "return_code": 6
   }
 }

--- a/tests/c_programs/int_wrapping/int_wrapping.c
+++ b/tests/c_programs/int_wrapping/int_wrapping.c
@@ -1,0 +1,9 @@
+int main(void) {
+    int int_max = 2147483647; // + 1 to go to zero
+    int int_min = -2147483648; //-1 to go to int max
+
+    int wrapped_max = int_max + 1; // wraps to zero
+    int wrapped_min = int_min -1; // wraps to int max
+
+    return int_min + 1 + wrapped_max + 3 + - wrapped_min - 4 + int_max - int_min;
+}

--- a/tests/c_programs/int_wrapping/invalid_parse/above_max.c
+++ b/tests/c_programs/int_wrapping/invalid_parse/above_max.c
@@ -1,0 +1,5 @@
+
+int main(void) {
+    int int_max = 2147483648; //too large
+    return int_max;
+}

--- a/tests/c_programs/int_wrapping/invalid_parse/below_min.c
+++ b/tests/c_programs/int_wrapping/invalid_parse/below_min.c
@@ -1,0 +1,4 @@
+int main(void) {
+    int int_min = -2147483649; // too small
+    return int_min;
+}

--- a/tests/c_programs/int_wrapping/loop_wrapping.c
+++ b/tests/c_programs/int_wrapping/loop_wrapping.c
@@ -1,0 +1,10 @@
+int main(void) {
+    int i = 2147483646;
+    int b = 0;
+
+    while (i > 0) {
+        b++;
+        i++;
+    }
+    return b;
+}

--- a/tests/c_programs/int_wrapping/overflow_tests.c
+++ b/tests/c_programs/int_wrapping/overflow_tests.c
@@ -1,0 +1,28 @@
+int main(void) {
+    int int_max = 2147483647;
+    int int_min = -2147483648;
+
+    // Test INT_MAX overflow
+    int b = int_max + 1;  // Should wrap to INT_MIN
+    
+    // Test INT_MIN underflow
+    int d = int_min - 1;  // Should wrap to INT_MAX
+    
+    // Test multiplication overflow
+    int e = 1073741824;  // 2^30
+    int f = e * 2;       // Should be INT_MIN
+    
+    // Test negative multiplication overflow
+    int g = -1073741824;
+    int h = g * 2;       // Should be INT_MIN
+    
+    // Test edge cases with arithmetic
+    int n = 2147483640;
+    int o = n + 10;  // Wraps to negative
+    
+    // Test subtraction underflow
+    int p = -2147483640;
+    int q = p - 10;  // Wraps to positive
+
+    return (b == int_min) + (d == int_max) + (f == int_min) + (h == int_min) +  (o < 0) + (q > 0);
+}

--- a/tests/c_programs/loops/complex_loop_expressions_simple.c
+++ b/tests/c_programs/loops/complex_loop_expressions_simple.c
@@ -1,0 +1,51 @@
+// Simplified test for complex expressions in loop headers
+// Uses only features supported by the compiler grammar
+
+int main(void) {
+    int total = 0;
+    int x = 10;
+    int y = 5;
+    int z = 8;
+    
+    // Test 1: Complex condition with ternary operator
+    for (int j = 0; j < (x > y ? z : x); j++) {
+        total++;
+    }
+    // x > y is true, so loop runs while j < z (8 times)
+    // total = 8
+    
+    // Test 2: Assignment in initialization
+    int a = 0;
+    for (int i = (a = 3); i < 6; i++) {
+        total = total + i;
+    }
+    // i: 3, 4, 5
+    // total = 8 + 3 + 4 + 5 = 20
+    
+    // Test 3: Compound assignment in post-expression
+    int k;
+    for (k = 0; k < 9; k += 3) {
+        total = total + k;
+    }
+    // k: 0, 3, 6
+    // total = 20 + 0 + 3 + 6 = 29
+    
+    // Test 4: Postfix increment in condition
+    int count = 0;
+    int limit = 3;
+    while (count++ < limit) {
+        total++;
+    }
+    // count: 0->1 (total++), 1->2 (total++), 2->3 (total++), 3->4 (exit)
+    // total = 29 + 3 = 32
+    
+    // Test 5: Prefix decrement in condition
+    int down = 3;
+    while (--down) {
+        total = total + down;
+    }
+    // down: 3->2 (total+=2), 2->1 (total+=1), 1->0 (exit)
+    // total = 32 + 2 + 1 = 35
+    
+    return total;
+}

--- a/tests/c_programs/loops/debug_conditional_break.c
+++ b/tests/c_programs/loops/debug_conditional_break.c
@@ -1,0 +1,17 @@
+// Test conditional break after inner loop
+
+int main(void) {
+    int result = 0;
+    
+    for (int i = 0; i < 2; i++) {
+        for (int j = 0; j < 2; j++) {
+            result++;
+        }
+        // Break AFTER inner loop completes
+        if (i == 0) {
+            break;
+        }
+    }
+    
+    return result;  // Should be 2
+}

--- a/tests/c_programs/loops/debug_middle_break.c
+++ b/tests/c_programs/loops/debug_middle_break.c
@@ -1,0 +1,21 @@
+// Test break at middle level of three-level loop
+
+int main(void) {
+    int result = 0;
+    
+    for (int i = 0; i < 2; i++) {
+        for (int j = 0; j < 3; j++) {
+            for (int k = 0; k < 2; k++) {
+                result++;
+            }
+            if (j == 1 && i == 0) {
+                break;  // Break middle loop when i==0, j==1
+            }
+        }
+    }
+    // i=0: j=0(k=0,1), j=1(k=0,1,break) -> 4 iterations
+    // i=1: j=0(k=0,1), j=1(k=0,1), j=2(k=0,1) -> 6 iterations
+    // Total: 10
+    
+    return result;
+}

--- a/tests/c_programs/loops/deeply_nested_loops.c
+++ b/tests/c_programs/loops/deeply_nested_loops.c
@@ -1,0 +1,87 @@
+// Test for break/continue in deeply nested loops
+// Tests break and continue behavior with 3+ levels of nesting
+// Simplified to avoid overflow and infinite loop issues
+
+int main(void) {
+    int result = 0;
+    
+    // Test 1: Three levels with break statements
+    for (int i = 0; i < 2; i++) {
+        for (int j = 0; j < 2; j++) {
+            for (int k = 0; k < 3; k++) {
+                result++;
+                if (k == 1) {
+                    break;  // Break innermost loop when k==1
+                }
+            }
+            if (j == 1 && i == 0) {
+                break;  // Break middle loop 
+            }
+        }
+    }
+    // Expected: result = 6
+    
+    // Test 2: Three levels with continue statements  
+    int count = 0;
+    for (int a = 0; a < 2; a++) {
+        for (int b = 0; b < 3; b++) {
+            if (b == 1) {
+                continue;  // Skip b==1
+            }
+            for (int c = 0; c < 2; c++) {
+                if (c == 0 && a == 1) {
+                    continue;  // Skip c==0 when a==1
+                }
+                count++;
+            }
+        }
+    }
+    result = result + count;
+    // Expected: count = 7, result = 13
+    
+    // Test 3: Mixed loop types with break/continue
+    int sum = 0;
+    int x = 0;
+    while (x < 2) {
+        for (int y = 0; y < 2; y++) {
+            int z = 0;
+            do {
+                sum++;
+                if (z == 0 && y == 1) {
+                    z++;
+                    continue;  // Skip rest of iteration
+                }
+                sum++;
+                z++;
+            } while (z < 2);
+            if (y == 0 && x == 1) {
+                break;  // Break for loop
+            }
+        }
+        x++;
+    }
+    result = result + sum;
+    // Expected: sum = 12, result = 25
+    
+    // Test 4: Five levels with early exit using goto
+    int deep = 0;
+    for (int l1 = 0; l1 < 2; l1++) {
+        for (int l2 = 0; l2 < 2; l2++) {
+            for (int l3 = 0; l3 < 2; l3++) {
+                for (int l4 = 0; l4 < 2; l4++) {
+                    for (int l5 = 0; l5 < 2; l5++) {
+                        deep++;
+                        if (deep == 10) {
+                            goto exit_all;  // Use goto to exit all loops
+                        }
+                    }
+                }
+            }
+        }
+    }
+    exit_all:
+    result = result + deep;  // Add 10 to result
+    // Expected: result = 25 + 10 = 35
+    
+    return result;
+}

--- a/tests/c_programs/loops/empty_for_components.c
+++ b/tests/c_programs/loops/empty_for_components.c
@@ -1,0 +1,54 @@
+// Test for empty for-loop components
+// Tests various combinations of missing for-loop components
+
+int main(void) {
+    int count = 0;
+    int i = 5;
+    
+    // Test 1: Missing initialization only
+    for (; i < 10; i++) {
+        count++;
+    }
+    
+    // Test 2: Missing post-expression only
+    for (int j = 0; j < 3;) {
+        count++;
+        j++;
+    }
+    
+    // Test 3: Missing condition only (with break to avoid infinite loop)
+    for (int k = 0; ; k++) {
+        count++;
+        if (k >= 2) {
+            break;
+        }
+    }
+    
+    // Test 4: Missing init and post
+    int m = 0;
+    for (; m < 2;) {
+        count++;
+        m++;
+    }
+    
+    // Test 5: Missing init and condition (with break)
+    int n = 0;
+    for (;; n++) {
+        count++;
+        if (n >= 1) {
+            break;
+        }
+    }
+    
+    // Test 6: Missing condition and post (with break)
+    for (int p = 0;;) {
+        count++;
+        p++;
+        if (p >= 2) {
+            break;
+        }
+    }
+    
+    // count should be: 5 + 3 + 3 + 2 + 2 + 2 = 17
+    return count;
+}

--- a/tests/c_programs/loops/nested_dowhile_continue.c
+++ b/tests/c_programs/loops/nested_dowhile_continue.c
@@ -1,0 +1,85 @@
+// Test for continue in nested do-while loops
+// Tests the behavior of continue statements in various nested do-while configurations
+
+int main(void) {
+    int count = 0;
+    
+    // Test 1: Continue in inner do-while
+    int i = 0;
+    do {
+        int j = 0;
+        do {
+            j++;
+            if (j == 2) {
+                continue;  // Skip when j == 2
+            }
+            count++;
+        } while (j < 4);
+        i++;
+    } while (i < 2);
+    // Inner loop: j=1(count++), j=2(continue), j=3(count++), j=4(count++)
+    // Runs twice (i=0,1), so count = 3 * 2 = 6
+    
+    // Test 2: Continue in outer do-while
+    int k = 0;
+    do {
+        k++;
+        if (k == 2) {
+            continue;  // Skip rest when k == 2
+        }
+        int m = 0;
+        do {
+            count++;
+            m++;
+        } while (m < 2);
+    } while (k < 3);
+    // k=1: inner runs twice (count += 2)
+    // k=2: continue (inner doesn't run)
+    // k=3: inner runs twice (count += 2)
+    // count = 6 + 2 + 2 = 10
+    
+    // Test 3: Multiple continues at different levels
+    int n = 0;
+    do {
+        n++;
+        int p = 0;
+        do {
+            p++;
+            if (p == 1 && n == 2) {
+                continue;  // Continue inner when p==1 and n==2
+            }
+            if (p == 3) {
+                count++;
+                continue;  // Always continue when p==3
+            }
+            count += 2;
+        } while (p < 3);
+        
+    } while (n < 2);
+    // n=1: p=1(count+=2), p=2(count+=2), p=3(count++)
+    // n=2: p=1(continue), p=2(count+=2), p=3(count++)
+    // count = 10 + 5 + 3 = 18
+    
+    // Test 4: Triple nested do-while with continue
+    int x = 0;
+    do {
+        x++;
+        int y = 0;
+        do {
+            y++;
+            int z = 0;
+            do {
+                z++;
+                if (z == 2) {
+                    continue;  // Skip in innermost loop
+                }
+                count++;
+            } while (z < 3);
+        } while (y < 1);
+    } while (x < 2);
+    // Innermost: z=1(count++), z=2(continue), z=3(count++)
+    // Middle runs once (y<1), outer runs twice (x<2)
+    // count = 18 + (2 * 1 * 2) = 22
+    
+    return count;
+}

--- a/tests/c_programs/switch/complex_const_int.c
+++ b/tests/c_programs/switch/complex_const_int.c
@@ -1,0 +1,108 @@
+int main(void) {
+    int x = 18;
+    int result = 0;
+    
+    // Test switch with valid complex constant expressions
+    switch(x) {
+        // Basic arithmetic
+        case 2 + 3:  // 5
+            result = 1;
+            break;
+            
+        // Multiplication and division
+        case 2 * 6:  // 12
+            result = 3;
+            break;
+            
+        case 20 / 5:  // 4
+            result = 4;
+            break;
+            
+        // Modulo
+        case 17 % 7:  // 3
+            result = 5;
+            break;
+            
+        // Bitwise operations
+        case 15 & 7:  // 7
+            result = 7;
+            break;
+            
+        case 1 << 3:  // 8
+            result = 9;
+            break;
+            
+        case 64 >> 2:  // 16
+            result = 10;
+            break;
+            
+        // Unary operations
+        case -(-10):  // 10
+            result = 11;
+            break;
+            
+        case ~(~20):  // 20
+            result = 12;
+            break;
+            
+        case !0:  // 1
+            result = 13;
+            break;
+            
+        case !5:  // 0
+            result = 14;
+            break;
+            
+        // Complex nested expressions
+        case ((8 >> 1) + 2) * 3:  // 18
+            result = 16;
+            break;
+            
+        case (15 & 12) | (3 ^ 1):  // 14
+            result = 17;
+            break;
+            
+        // Edge cases
+        case 2147483647:  // INT_MAX
+            result = 26;
+            break;
+            
+        case -2147483647 - 1:  // INT_MIN (avoiding direct -2147483648)
+            result = 27;
+            break;
+            
+        // Complex bitwise combination
+        case (255 << 8) | 66:  // 65280 | 66 = 65346
+            result = 28;
+            break;
+            
+        default:
+            result = 100;
+            break;
+    }
+    
+    // Another switch to test that same values are OK in different switches
+    switch(x) {
+        case 1 + 1:  // 2
+            result = 200;
+            break;
+            
+        case 3 * 3:  // 9
+            result = 201;
+            break;
+            
+        case 100 / 5:  // 20
+            result = 202;
+            break;
+            
+        case (1 << 4) - 1:  // 15
+            result = 203;
+            break;
+            
+        case ~(-4):  // 3 (bitwise NOT of -4)
+            result = 204;
+            break;
+    }
+    
+    return result;
+}

--- a/tests/c_programs/switch/invalid_parse/declaration_after_label.c
+++ b/tests/c_programs/switch/invalid_parse/declaration_after_label.c
@@ -1,0 +1,8 @@
+int main(void) {
+int no_body = 1;
+    switch (1)
+      case 1:
+        int whatever = 0;
+
+    return no_body;
+}

--- a/tests/c_programs/switch/invalid_semantics/duplicate_cases.c
+++ b/tests/c_programs/switch/invalid_semantics/duplicate_cases.c
@@ -1,0 +1,108 @@
+int main(void) {
+    int x = 5;
+    int result = 0;
+    
+    // Test duplicate case values - should trigger errors
+    switch(x) {
+        // Direct duplicate
+        case 5:
+            result = 1;
+            break;
+            
+        case 5:  // ERROR: Duplicate case value
+            result = 2;
+            break;
+            
+        // Duplicate via arithmetic expressions
+        case 2 + 3:  // 5
+            result = 3;
+            break;
+            
+        case 10 - 5:  // 5 - ERROR: Duplicate (same as 2+3)
+            result = 4;
+            break;
+            
+        case 20 / 4:  // 5 - ERROR: Another duplicate
+            result = 5;
+            break;
+            
+        // Duplicate via bitwise operations
+        case 8 | 4:  // 12
+            result = 6;
+            break;
+            
+        case 2 * 6:  // 12 - ERROR: Duplicate (same as 8|4)
+            result = 7;
+            break;
+            
+        // Duplicate unary results
+        case !0:  // 1
+            result = 8;
+            break;
+            
+        case 5 > 3:  // 1 - ERROR: Duplicate (same as !0)
+            result = 9;
+            break;
+            
+        case 4 == 4:  // 1 - ERROR: Another duplicate
+            result = 10;
+            break;
+            
+        case 10 >= 10:  // 1 - ERROR: Another duplicate
+            result = 11;
+            break;
+            
+        case 5 && 3:  // 1 - ERROR: Another duplicate
+            result = 12;
+            break;
+            
+        // Duplicate zeros
+        case !5:  // 0
+            result = 13;
+            break;
+            
+        case 3 < 2:  // 0 - ERROR: Duplicate (same as !5)
+            result = 14;
+            break;
+            
+        case 5 != 5:  // 0 - ERROR: Another duplicate
+            result = 15;
+            break;
+            
+        case 9 <= 8:  // 0 - ERROR: Another duplicate
+            result = 16;
+            break;
+            
+        case 0 || 0:  // 0 - ERROR: Another duplicate
+            result = 17;
+            break;
+            
+        // Complex expression duplicates
+        case (2 + 3) * 2:  // 10
+            result = 18;
+            break;
+            
+        case -(-10):  // 10 - ERROR: Duplicate
+            result = 19;
+            break;
+            
+        case (5 - 3) * 5:  // 10 - ERROR: Another duplicate
+            result = 20;
+            break;
+            
+        // Multiple defaults
+        default:
+            result = 100;
+            break;
+            
+        default:  // ERROR: Duplicate default
+            result = 101;
+            break;
+            
+        default:  // ERROR: Another duplicate default
+            result = 102;
+            break;
+    }
+    
+    return result;
+}

--- a/tests/c_programs/switch/invalid_semantics/non_const_cases.c
+++ b/tests/c_programs/switch/invalid_semantics/non_const_cases.c
@@ -1,0 +1,58 @@
+int main(void) {
+    int x = 5;
+    int y = 10;
+    int result = 0;
+    
+    // Test non-constant case expressions - should all error
+    switch(x) {
+        case y:  // ERROR: y is not a constant expression
+            result = 1;
+            break;
+            
+        case x + 1:  // ERROR: x is not a constant
+            result = 2;
+            break;
+            
+        case y * 2:  // ERROR: y is not a constant
+            result = 3;
+            break;
+            
+        case (x > y ? 1 : 0):  // ERROR: x and y are not constants
+            result = 4;
+            break;
+            
+        // These should work - they're constant expressions
+        case 5:
+            result = 5;
+            break;
+            
+        case 2 + 3:  // OK: constant expression
+            result = 6;
+            break;
+            
+        // Assignment is not a constant expression
+        case (result = 7):  // ERROR: assignment is not constant
+            result = 8;
+            break;
+            
+        // Increment/decrement are not constant
+        case ++result:  // ERROR: increment is not constant
+            result = 9;
+            break;
+            
+        case result++:  // ERROR: postfix increment is not constant
+            result = 10;
+            break;
+            
+        // Compound assignments are not constant
+        case (result += 5):  // ERROR: compound assignment is not constant
+            result = 11;
+            break;
+            
+        default:
+            result = 100;
+            break;
+    }
+    
+    return result;
+}

--- a/tests/c_programs/switch/invalid_semantics/redefination_in_case.c
+++ b/tests/c_programs/switch/invalid_semantics/redefination_in_case.c
@@ -1,0 +1,9 @@
+int main(void) {
+    int no_body = 1;
+    switch (1)
+      case 1:
+        ;
+        int no_body = 0;
+
+    return no_body;
+}

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -417,7 +417,10 @@ fn test_warning(test_file: &str, warning: &str) {
 
 #[test]
 fn test_switch_unreachable() {
-    let files = ["writing-a-c-compiler-tests/tests/chapter_8/valid/extra_credit/switch_no_case.c", "writing-a-c-compiler-tests/tests/chapter_8/valid/extra_credit/switch_nested_cases.c"];
+    let files = [
+        "writing-a-c-compiler-tests/tests/chapter_8/valid/extra_credit/switch_no_case.c",
+        "writing-a-c-compiler-tests/tests/chapter_8/valid/extra_credit/switch_nested_cases.c",
+    ];
 
     for file in files {
         test_warning(file, "-Wswitch-unreachable")


### PR DESCRIPTION
This PR completes Chapter 8 of "Writing a C Compiler" by implementing switch statements with full support for case labels, default labels, and fallthrough behavior. Additionally, several important improvements were made to the parser and compiler infrastructure.

## Key Changes

### Switch Statement Implementation
- Added `switch`, `case`, and `default` statement parsing and code generation
- Implemented constant expression evaluation for case labels  
- Added duplicate case detection with support for complex constant expressions

### Fix labeling
- Fixed incorrect labeling from the previous PR impacting break statements

### Parser Enhancements
- Migrated all statement types to use `SpannedStmt` structure for consistent span tracking
- Fixed INT_MIN parsing issue by deferring integer literal parsing from lexer to parser stage

### Safety & Developer Experience
- Added comprehensive test cases for switch statements with complex constant expressions
- Created integer overflow/underflow tests to verify deterministic wrapping behavior
- Updated README to document compiler warnings and guaranteed integer wrapping semantics
- Enhanced documentation of span-aware error reporting and pretty-printed AST features

## Technical Details

The lexer now stores integer constants as strings (`Token::ConstantInt(String)`) rather than parsed integers, allowing the parser to handle edge cases like INT_MIN correctly.

Duplicate case detection works across complex constant expressions like `(1 << 3)` evaluating to the same value as `8`.

## Testing

Added comprehensive test coverage including:
- Complex constant integer expressions in switch cases
- Integer wrapping behavior verification  
- Duplicate case detection across different expression forms
- Edge cases for INT_MIN/INT_MAX boundaries

All existing tests continue to pass, and the implementation handles all Chapter 8 requirements plus extra credit.